### PR TITLE
scaffolding-node-modules: Add reference to external repository

### DIFF
--- a/no-module/scaffolding-node-modules/README.md
+++ b/no-module/scaffolding-node-modules/README.md
@@ -1,0 +1,19 @@
+# Scaffolding Node Modules, NodeJS
+
+Cool facts about node modules directory.
+
+- Can be created manually.
+- Is looked up by NodeJS when requiring module.
+- Imports can be configured through `package.json`.
+- Is subject to [NodeJS module resolution algorithm](https://nodejs.org/api/modules.html#all-together)
+- Manual creation can be used to see how resolution or package.json configuration works.
+
+_Note: It is difficult to experiment in large projects. If node modules have a lot of libraries, there is no guarantee that some may affect our imports._
+
+## Proof of Concept
+
+Repository: [Scaffolding node modules](https://github.com/srele96/scaffolding-node-modules)
+
+In this repository, I have manually created node_modules directory.
+
+Added packages inside it and required them from script, then ran the script with NodeJS.


### PR DESCRIPTION
Setting up node_modules from scratch required a new repository.
Empty repository and node modules directory made sure that example either
works or not.

Referencing an external repository with this example will expose it to
whoever views the README file here.

This project is a collection of my research and I want to keep it that
way. However, node module resolution research required me to create
a new repo.