### PR TITLE
Remove .idea from VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,5 @@ yarn-error.log
 !**/.yarn/sdks
 !**/.yarn/versions
 
-# https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems
-**/.idea/workspace.xml
-**/.idea/usage.statistics.xml
-**/.idea/shelf
-**/.idea/*.iml
-**/.idea/modules.xml
-
+**/.idea
 env

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,5 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="PrettierConfiguration">
-    <option name="myRunOnSave" value="true" />
-    <option name="myRunOnReformat" value="true" />
-    <option name="myFilesPattern" value="{**/*,*}.{*}" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
After two months of using WebStorm and configuring gitignore i came to a
conclusion. Ignore the whole .idea directory.

The .idea directory saves WebStorm configuration. I do not need to share
or reuse configuration. It was very annoying configuring .gitignore
every time there was untracked change. I didn't have any benefits from
adding .idea to VCS.