### PR TITLE
Fix wrong port

### DIFF
--- a/tcp-packages/package.json
+++ b/tcp-packages/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start:serve-data": "nodemon serve-data.js",
     "start:serve-client": "nodemon serve-client.js",
-    "start:watching-tcp-traffic": "sudo tcpdump -v -i any port 3005"
+    "start:watching-tcp-traffic": "sudo tcpdump -v -i any port 3000"
   },
   "dependencies": {
     "express": "^4.18.1"


### PR DESCRIPTION
I should watch TCP traffic on port of server that serves data. I used
port 3005 because I thought 3000 was taken. When I saw that 3000 was not
taken, I used port 3000. However, I forgot to change the script to use
3000 aswell.