### PR TITLE
workflow: create issue questionnaire

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-questionnaire.md
+++ b/.github/ISSUE_TEMPLATE/issue-questionnaire.md
@@ -1,0 +1,24 @@
+---
+name: Issue Questionnaire
+about: Answer the questions to provide quality issue context.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## What
+
+_Describe the goal, what do you want to do, create or anything else._
+
+## Why
+
+_Describe the motive._
+
+## How
+
+_Optional. Suggestion or description how to approach the proposed topic._
+
+## Additional information
+
+_Optional. Anything that is relevant to the topic._


### PR DESCRIPTION
Add issue questionnaire in form of template.

I don't have a structure for issues, but try to follow one.

This commit adds general-purpose issue template to try and improve that.