### PR TITLE
refactor: remove prettier from lockfile

### DIFF
--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -12,6 +12,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"javascript@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "javascript@workspace:."
+  languageName: unknown
+  linkType: soft
+
 "new@workspace:packages/new":
   version: 0.0.0-use.local
   resolution: "new@workspace:packages/new"
@@ -19,22 +25,5 @@ __metadata:
     commander: 9.4.0
   bin:
     new: ./index.js
-  languageName: unknown
-  linkType: soft
-
-"prettier@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "prettier@npm:2.6.2"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 48d08dde8e9fb1f5bccdd205baa7f192e9fc8bc98f86e1b97d919de804e28c806b0e6cc685e4a88211aa7987fa9668f30baae19580d87ced3ed0f2ec6572106f
-  languageName: node
-  linkType: hard
-
-"sk-experiments@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "sk-experiments@workspace:."
-  dependencies:
-    prettier: ^2.6.2
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Remove prettier from the lock file. I ran yarn install and saw prettier changes.
I forgot to run yarn install after updating package.json.