### PR TITLE
format code on ci

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,14 @@
+name: format
+on: push
+jobs:
+  check-javascript-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          # Match local and CI version. I use version 16 because it's LTS.
+          node-version: '16'
+      - run: cd javascript
+      - run: yarn install
+      - run: yarn ci:format

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,6 +9,4 @@ jobs:
         with:
           # Match local and CI version. I use version 16 because it's LTS.
           node-version: '16'
-      - run: cd javascript
-      - run: yarn install
-      - run: yarn ci:format
+      - run: cd ./javascript && yarn && yarn ci:format

--- a/javascript/experiments/async-currying/index.js
+++ b/javascript/experiments/async-currying/index.js
@@ -4,7 +4,9 @@ async function a(a) {
   console.log({ a });
   return async function b(b) {
     console.log({ a, b });
-    return async function c(c) {console.log({ a, b, c });};
+    return async function c(c) {
+      console.log({ a, b, c });
+    };
   };
 }
 

--- a/javascript/experiments/async-currying/index.js
+++ b/javascript/experiments/async-currying/index.js
@@ -4,9 +4,7 @@ async function a(a) {
   console.log({ a });
   return async function b(b) {
     console.log({ a, b });
-    return async function c(c) {
-      console.log({ a, b, c });
-    };
+    return async function c(c) {console.log({ a, b, c });};
   };
 }
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -7,7 +7,8 @@
     "packages/*"
   ],
   "scripts": {
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "ci:format": "prettier -c ."
   },
   "devDependencies": {
     "prettier": "^2.7.1"


### PR DESCRIPTION
- Consider using [caching global dependencies data](https://github.com/actions/setup-node#caching-global-packages-data), but I decided not to. The project has only one dev dependency. Installing is fast and we don't need caching.
- Configure check to work for all branches. Provide early feedback before a pull request. We can fix the CI mistake early.