### PR TITLE
create readme for new experiment

### DIFF
--- a/javascript/packages/new/templates.js
+++ b/javascript/packages/new/templates.js
@@ -1,4 +1,4 @@
-{
+const PACKAGE_JSON = `{
   "name": "{name}",
   "version": "0.1.0",
   "description": "{description}",
@@ -11,4 +11,10 @@
     "url": "https://github.com/srele96/sk-experiments/issues"
   },
   "homepage": "https://github.com/srele96/sk-experiments#readme"
-}
+}`;
+
+const README_MD = `# {name}
+
+{description}`;
+
+module.exports = { PACKAGE_JSON, README_MD };

--- a/javascript/packages/new/templates.js
+++ b/javascript/packages/new/templates.js
@@ -13,10 +13,12 @@ const PACKAGE_JSON = `{
     "url": "https://github.com/srele96/sk-experiments/issues"
   },
   "homepage": "https://github.com/srele96/sk-experiments#readme"
-}`;
+}
+`;
 
 const README_MD = `# {name}
 
-{description}`;
+{description}
+`;
 
 module.exports = { PACKAGE_JSON, README_MD };

--- a/javascript/packages/new/templates.js
+++ b/javascript/packages/new/templates.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const PACKAGE_JSON = `{
   "name": "{name}",
   "version": "0.1.0",


### PR DESCRIPTION
## What changed

Create a readme file for the new experiment to use consistent experiment name and description for README.md and package.json file.

Refactor the code not to use the file template. Code uses a template from a string. That is much easier to maintain and change. Importing a template from a js file is much less code than reading a file.

## Why was the change needed

Use consistent experiment names and descriptions.
Importing a template from a js file is much less code than reading a file.

## What was the previous behavior

We didn't create README.md for the new experiment. The code was reading template content from the file.

## Checklist

- [x] Write a well-written and structured commit message with high-quality context
- [x] If you created an experiment, add a link to it in `README.md`. Like `sk-experiments/README.md`, `sk-experiments/cpp/README.md`, etc.

## Commit

_When done, edit the pull request and add the commit content here._

```txt
feat: create a readme for a new experiment

Create a readme file for the new experiment to use consistent
experiment name and description for README.md and package.json file.

Refactor the code not to use the file template. Code uses a template
from a string. That is much easier to maintain and change. Importing
a template from a js file is much less code than reading a file.
```
