### PR TITLE
check cpp formatting using ci

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ insert_final_newline = true
 max_line_length = 80
 trim_trailing_whitespace = true
 
+[*.py]
+indent_size = 4
+
 [*.md]
 max_line_length = 0
 trim_trailing_whitespace = false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,5 +8,14 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           # Match local and CI version. I use version 16 because it's LTS.
-          node-version: '16'
+          node-version: "16"
       - run: cd ./javascript && yarn && yarn ci:format
+  check-cpp-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          # Match local and CI version.
+          python-version: "3.10"
+      - run: cd ./cpp && python format.py --check

--- a/cpp/experiments/employee_factory/source/main.cpp
+++ b/cpp/experiments/employee_factory/source/main.cpp
@@ -16,7 +16,8 @@ int main() {
   thornhil_industries.Accept(
       std::make_unique<role::Maintenance>("Captain", "Feline"));
   thornhil_industries.Accept(std::make_unique<role::Operator>("Jane", "Doe"));
-  thornhil_industries.Accept(std::make_unique<role::Operator>("Hindrance", "Man"));
+  thornhil_industries.Accept(
+      std::make_unique<role::Operator>("Hindrance", "Man"));
 
   thornhil_industries.StartWorkHours();
 

--- a/cpp/format.py
+++ b/cpp/format.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+import os
+
+class Formatter:
+    def __init__(self):
+        self.extensions = ['.cpp', '.h', '.hpp']
+        self.files = []
+        self.find_files_with_extensions()
+
+    def find_files_with_extensions(self):
+        for root, _, filenames in os.walk('.'):
+            for filename in filenames:
+                has_valid_extension = os.path.splitext(filename)[1] in self.extensions
+                not_ignored = 'build' not in root
+                if has_valid_extension and not_ignored:
+                    self.files.append(os.path.join(root, filename))
+
+    def check_files(self):
+        print('Searching for unformatted files...')
+        for file in self.files:
+            # Use --output-replacements-xml to get a list of replacements that
+            # clang-format would make. If there are any, the file is not
+            # formatted.
+            result = subprocess.run(
+              ['clang-format', '--output-replacements-xml','-style=file', file],
+              stdout=subprocess.PIPE,
+              stderr=subprocess.PIPE
+            )
+            output = result.stdout.decode('utf-8')
+
+            not_formatted = '<replacement ' in output
+            if not_formatted:
+                print('File is not formatted', file)
+                exit(1)
+        print('All files are formatted.')
+
+    def format_files(self):
+        for file in self.files:
+            print('Formatting file: ' + file)
+            os.system('clang-format -i -style=file ' + file)
+
+def run_formatter():
+    formatter = Formatter()
+    if '--check' in sys.argv:
+        formatter.check_files()
+    else:
+        formatter.format_files()
+
+if __name__ == '__main__':
+    run_formatter()


### PR DESCRIPTION
## What changed

C++ experiments are now checked for formatting on CI, and we won't be able to merge unformatted code.

## Why was the change needed

I wanted consistent styling.

## What was the previous behavior

I could push unformatted code, and nothing would validate formatting.

## Checklist

- [x] Write a well-written and structured commit message with high-quality context
- [x] If you created an experiment, add a link to it in `README.md`. Like `sk-experiments/README.md`, `sk-experiments/cpp/README.md`, etc.

## Commit

_When done, edit the pull request and add the commit content here._

```txt
chore: add example title

I don't want to leave empty content so I have to add some example here.
```
