### PR TITLE
check full directory name

### DIFF
--- a/cpp/experiments/build-static-library/main.cpp
+++ b/cpp/experiments/build-static-library/main.cpp
@@ -5,7 +5,7 @@
 int main() {
   Point dot;
   std::cout << "Building a static library!";
-  std::cout << '{' << dot.x_coordinate << ", " << dot.y_coordinate <<'}';
+  std::cout << '{' << dot.x_coordinate << ", " << dot.y_coordinate << '}';
 
   return 0;
 }

--- a/cpp/format.py
+++ b/cpp/format.py
@@ -14,7 +14,11 @@ class Formatter:
         for root, _, filenames in os.walk('.'):
             for filename in filenames:
                 has_valid_extension = os.path.splitext(filename)[1] in self.extensions
-                not_ignored = 'build' not in root
+                # The file is always a child of all the directories in the
+                # path, so if any of the parent directories are 'build',
+                # we can ignore the file.
+                not_ignored = 'build' not in root.split(os.sep)
+
                 if has_valid_extension and not_ignored:
                     self.files.append(os.path.join(root, filename))
 


### PR DESCRIPTION
## What changed

We previously considered a path as a string and checked if it contains
"build" which yielded incorrect results when directory had a name like
"build-blah-blah". So the solution was to split path and check if any
directory is named "build".

## Why was the change needed

We should correctly match the directory by its full name.

## What was the previous behavior

Described in `What changed`.

## Checklist

- [x] Write a well-written and structured commit message with high-quality context
- [x] If you created an experiment, add a link to it in `README.md`. Like `sk-experiments/README.md`, `sk-experiments/cpp/README.md`, etc.

## Commit

_When done, edit the pull request and add the commit content here._

```txt
fix: check the full directory name

We previously considered a path as a string and checked if it contains
"build" which yielded incorrect results when directory had a name like
"build-blah-blah". So the solution was to split the path into directory
names and check against each.
```
