### PR TITLE
add links to algorithmic platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Srecko Kostic's collection of experiments and reading topic wishlist in form of 
 
 I start to like this repository. It serves as a history and a tool to reflect. I can see how much I've improved.
 
+## Algorithmic problems
+
+- [LeetCode - srele96](https://leetcode.com/srele96/)
+- [CodeForces - flexos96](https://codeforces.com/profile/flexos96)
+
 ## Experiments
 
 - [JavaScript](./javascript)


### PR DESCRIPTION
## What changed

Added links to leetcode and codeforces profiles.

## Why was the change needed

I wanted to add links to the locations where I do the effort to one place.

## What was the previous behavior

Didnt have links obviously.

## Checklist

- [x] Write a well-written and structured commit message with high-quality context
- [x] If you created an experiment, add a link to it in `README.md`. Like `sk-experiments/README.md`, `sk-experiments/cpp/README.md`, etc.

## Commit

_When done, edit the pull request and add the commit content here._

```txt
chore: add example title

I don't want to leave empty content so I have to add some example here.
```
